### PR TITLE
Replaced calls to depricated readdir_r with readdir

### DIFF
--- a/hw/9pfs/virtio-9p-handle.c
+++ b/hw/9pfs/virtio-9p-handle.c
@@ -152,7 +152,14 @@ static int handle_readdir_r(FsContext *ctx, V9fsFidOpenState *fs,
                             struct dirent *entry,
                             struct dirent **result)
 {
-    return readdir_r(fs->dir, entry, result);
+    errno = 0;
+    *result = readdir(fs->dir);
+
+    if (*result != NULL) {
+        *entry = **result;
+    }
+
+    return errno;
 }
 
 static void handle_seekdir(FsContext *ctx, V9fsFidOpenState *fs, off_t off)

--- a/hw/9pfs/virtio-9p-local.c
+++ b/hw/9pfs/virtio-9p-local.c
@@ -393,7 +393,14 @@ static int local_readdir_r(FsContext *ctx, V9fsFidOpenState *fs,
     int ret;
 
 again:
-    ret = readdir_r(fs->dir, entry, result);
+    errno = 0;
+    *result = readdir(fs->dir);
+    ret = errno;
+
+    if (*result != NULL) {
+        *entry = **result;
+    }
+
     if (ctx->export_flags & V9FS_SM_MAPPED) {
         entry->d_type = DT_UNKNOWN;
     } else if (ctx->export_flags & V9FS_SM_MAPPED_FILE) {

--- a/hw/9pfs/virtio-9p-proxy.c
+++ b/hw/9pfs/virtio-9p-proxy.c
@@ -681,7 +681,14 @@ static int proxy_readdir_r(FsContext *ctx, V9fsFidOpenState *fs,
                            struct dirent *entry,
                            struct dirent **result)
 {
-    return readdir_r(fs->dir, entry, result);
+    errno = 0;
+    *result =  readdir(fs->dir);
+
+    if (*result != NULL) {
+        *entry = **result;
+    }
+
+    return errno;
 }
 
 static void proxy_seekdir(FsContext *ctx, V9fsFidOpenState *fs, off_t off)


### PR DESCRIPTION
Hi,

This is Timothy Trindle. I talked to you after lecture today.

I took the simple aproach and simply replaced each instance of readdir_r. The man pages indicated that the return of readdir_r is equivalent to errno in readdir. I zero it out before calling to avoid picking up previous errors.
